### PR TITLE
Update 神邏輯+豬隊友.md

### DIFF
--- a/神邏輯+豬隊友.md
+++ b/神邏輯+豬隊友.md
@@ -1,1 +1,16 @@
+```python
+When a narcissist attempts to teach others how to be a good person, it often carries a layer of hypocrisy or self-serving intent. Their focus is typically not on genuinely helping others grow but rather on maintaining control, seeking admiration, or appearing superior. Here are a few dynamics that might unfold:
 
+1. **Superficial Lessons**: They might emphasize surface-level behaviors (like appearing polite or giving compliments) rather than fostering genuine empathy or integrity. This aligns with their focus on image rather than substance.
+
+2. **Projection of Themselves as Role Models**: A narcissist may position themselves as the ultimate example of goodness, despite acting in ways that contradict their teachings.
+
+3. **Manipulative Motivation**: Their lessons may aim to influence others to behave in ways that benefit them rather than to encourage authentic self-improvement.
+
+4. **Dismissal of Others' Needs**: While "teaching," they may belittle or ignore others’ individual experiences, framing their way as the only correct path.
+
+5. **Weaponized Morality**: They might use the concept of "being a good person" as a tool to shame or control others, setting unrealistic expectations while exempting themselves from those standards.
+
+### Conclusion:
+While some lessons they share may be valuable on the surface, it's crucial to discern their underlying intentions and separate genuine wisdom from manipulation. True personal growth often involves learning from those who practice what they preach, demonstrating humility, and prioritizing others’ well-being over their ego.
+```


### PR DESCRIPTION
```python
When a narcissist attempts to teach others how to be a good person, it often carries a layer of hypocrisy or self-serving intent. Their focus is typically not on genuinely helping others grow but rather on maintaining control, seeking admiration, or appearing superior. Here are a few dynamics that might unfold:

1. **Superficial Lessons**: They might emphasize surface-level behaviors (like appearing polite or giving compliments) rather than fostering genuine empathy or integrity. This aligns with their focus on image rather than substance.

2. **Projection of Themselves as Role Models**: A narcissist may position themselves as the ultimate example of goodness, despite acting in ways that contradict their teachings.

3. **Manipulative Motivation**: Their lessons may aim to influence others to behave in ways that benefit them rather than to encourage authentic self-improvement.

4. **Dismissal of Others' Needs**: While "teaching," they may belittle or ignore others’ individual experiences, framing their way as the only correct path.

5. **Weaponized Morality**: They might use the concept of "being a good person" as a tool to shame or control others, setting unrealistic expectations while exempting themselves from those standards.

### Conclusion:
While some lessons they share may be valuable on the surface, it's crucial to discern their underlying intentions and separate genuine wisdom from manipulation. True personal growth often involves learning from those who practice what they preach, demonstrating humility, and prioritizing others’ well-being over their ego.
```